### PR TITLE
Scheduled posts

### DIFF
--- a/.github/workflows/scheduled-posts.yml
+++ b/.github/workflows/scheduled-posts.yml
@@ -1,0 +1,13 @@
+name: Build every hour
+
+on:
+  schedule:
+   - cron: '0 * * * *'
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+    - name: curl
+      uses: wei/curl@master
+      with:
+        args: "-X POST -H 'Authorization: token ${{ secrets.PAGES_ACCESS_TOKEN }}' -H 'Accept: application/vnd.github.ant-man-preview+json' https://api.github.com/repos/excellalabs/blog-in-a-box/pages/builds"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,23 @@ This project is created to use the following:
 | Spelling | `spellcheck` | The [cSpell commands](https://www.npmjs.com/package/cspell) | |
 | Linting | `lint` | The [markdownlint-cli commands](https://github.com/igorshubovych/markdownlint-cli) | |
 | Build | `build` | `bundle exec jekyll build` | |
+
+### Setting up Scheduled Posts
+
+By default, this blog has a GitHub Action that will run to publish every hour. That way, you can create a post for the future, and when the build runs and that post is no longer in the future, it will be published.
+
+You'll need to take one of two actions. If you don't want scheduled posts, delete `scheduled-posts.yml` from the `.github` directory.
+
+If you do want scheduled posts: 
+
+* You'll need to generate a token called `PAGES_ACCESS_TOKEN` and save it, [as described here](https://seankilleen.com/2020/02/how-to-deploy-github-pages-on-a-schedule-to-publish-future-posts/). The general summary is:
+  * Go to [your GitHub tokens settings](https://github.com/settings/tokens)
+  * Click the button to create a new token, and give it a name like "Scheduled Posts" or similar.
+  * For the permissions, specify `public_repo`.
+  * Copy the Access token for use in the next step.
+* Add the secret for GitHub actions
+  * Go into the settings of your GitHub repository.
+  * Select `Secrets --> Actions` from the left-hand menu.
+  * Click the `New Repository Secret` button
+  * Name the secret `PAGES_ACCESS_TOKEN` and paste the value in.
+* Update the repository value in the `scheduled-posts.yml` file -- instead of `excellalabs/blog-in-a-box`, use your username and repository name.

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -14,6 +14,7 @@ remote_theme           : "mmistakes/minimal-mistakes@4.24.0"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings
+future                   : false # whether to publish future posts by default
 locale                   : "en-US"
 title                    : "Blog in a Box Demo Site"
 title_separator          : "-"


### PR DESCRIPTION
Supports #11.

We still need to set up the actual token and pages deployment etc.